### PR TITLE
macOS CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,10 @@ jobs:
       rust: stable
 
     - script: cargo test
+      name: "macOS Stable"
+      rust: stable
+
+    - script: cargo test
       name: "Beta"
       rust: beta
 


### PR DESCRIPTION
Add CI for testing on macOS.

Tests already seem to pass on macOS so it can be be helpful to keep track of our support for it.